### PR TITLE
Named ETS tables

### DIFF
--- a/test/immortal/ets_table_manager_test.exs
+++ b/test/immortal/ets_table_manager_test.exs
@@ -38,7 +38,14 @@ defmodule Immortal.ETSTableManagerTest do
     {:ok, manager: manager}
   end
 
-  doctest Immortal.ETSTableManager
+
+  doctest TableManager
+
+  test "ETS table shares table consumer name when :named_table is passed" do
+    TableManager.start_link(TableConsumer, [:public, :named_table])
+    info = :ets.info(TableConsumer)
+    assert info[:type] == :set
+  end
 
   test "ETS table attributes can be customized when manager starts" do
     {:ok, manager} = TableManager.start_link(TableConsumer, [:ordered_set])


### PR DESCRIPTION
This allows ETS tables managed by Immmortal to have names, which makes
it easier to read efficiently from the consumer process, because `:ets`
can be called directly rather than going through a GenServer.
