### PR TITLE
Fix typo in ETSTableManager docs

### DIFF
--- a/lib/immortal/ets_table_manager.ex
+++ b/lib/immortal/ets_table_manager.ex
@@ -25,7 +25,7 @@ defmodule Immortal.ETSTableManager do
 
       children = [
         worker(YourApp.TableConsumer, []),
-        worker(Immortal.EtsTableManager, [YourApp.TableConsumer, [:public]])
+        worker(Immortal.ETSTableManager, [YourApp.TableConsumer, [:public]])
       ]
 
   `Immortal.EtsTableManager` will wait until your `YourApp.TableConsumer`


### PR DESCRIPTION
The moduledoc here referred to `EtsTableManager` which had incorrect capitalisation.
